### PR TITLE
probe use health endpoint

### DIFF
--- a/charts/halo/values.yaml
+++ b/charts/halo/values.yaml
@@ -408,7 +408,7 @@ containerSecurityContext:
 livenessProbe:
   enabled: true
   httpGet:
-    path: /
+    path: /actuator/health
     port: "{{ .Values.haloScheme }}"
     scheme: "{{ .Values.haloScheme | upper }}"
     ## If using an HTTPS-terminating load-balancer, the probes may need to behave
@@ -437,7 +437,7 @@ livenessProbe:
 readinessProbe:
   enabled: true
   httpGet:
-    path: /
+    path: /actuator/health
     port: "{{ .Values.haloScheme }}"
     scheme: "{{ .Values.haloScheme | upper }}"
     ## If using an HTTPS-terminating load-balancer, the probes may need to behave
@@ -466,7 +466,7 @@ readinessProbe:
 startupProbe:
   enabled: false
   httpGet:
-    path: /
+    path: /actuator/health
     port: "{{ .Values.haloScheme }}"
     scheme: "{{ .Values.haloScheme | upper }}"
     ## If using an HTTPS-terminating load-balancer, the probes may need to behave


### PR DESCRIPTION
https://github.com/halo-dev/halo/issues/6815
在初始化的过程中，Probe不带`Accept: */*`请求头会返回404使探针失败
在类似树莓派这种性能较低的机器上，初始化时间比较长，会出现livenessProbe失败重启进程，导致初始化失败。
目前的几种解决方法：

1. probe新增`Accept: */*`请求头
2. 调大failureThreshold
3. 使用健康检查的endpoint uri

相比之下，使用健康检查的endpoint更为优雅