### PR TITLE
Bump PostgreSQL version to 18.x.x and MySQL version to 14.x.x

### DIFF
--- a/charts/halo/Chart.yaml
+++ b/charts/halo/Chart.yaml
@@ -21,9 +21,9 @@ dependencies:
     version: 2.x.x
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 12.x.x
+    version: 17.x.x
     condition: postgresql.enabled
   - name: mysql
     repository: https://charts.bitnami.com/bitnami
-    version: 9.x.x
+    version: 13.x.x
     condition: mysql.enabled

--- a/charts/halo/Chart.yaml
+++ b/charts/halo/Chart.yaml
@@ -21,9 +21,9 @@ dependencies:
     version: 2.x.x
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 17.x.x
+    version: 18.x.x
     condition: postgresql.enabled
   - name: mysql
     repository: https://charts.bitnami.com/bitnami
-    version: 13.x.x
+    version: 14.x.x
     condition: mysql.enabled


### PR DESCRIPTION
Fixes https://github.com/halo-dev/halo/issues/8023

```release-note
升级依赖 PostgreSQL 至 18.x.x 和 MySQL 至 14.x.x
```

